### PR TITLE
SRE-3246: Locked Module Dependencies Versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,14 @@ setuptools.setup(
     python_requires='>=3.9, <4',
     license="MIT",
     install_requires=[
-        "attrs",
+        "attrs==21.4.0",
         "grafanalib==0.6.3",
         "pydantic==1.9.1",
-        "pydantic-argparse",
-        "python-decouple",
-        "python-dotenv",
-        "PyYAML",
-        "requests",
+        "pydantic-argparse==0.5.0",
+        "python-decouple==3.6",
+        "python-dotenv==0.20.0",
+        "PyYAML==6.0",
+        "requests==2.28.0",
     ],
     package_dir={
         "": "src"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     install_requires=[
         "attrs",
         "grafanalib==0.6.3",
-        "pydantic",
+        "pydantic==1.9.1",
         "pydantic-argparse",
         "python-decouple",
         "python-dotenv",


### PR DESCRIPTION
## Description / why we need it:
- Locked module dependencies for `install_requires` in `setup.py`

## Types of changes
- [x] Update dependencies

## Link to jira ticket
https://hawkai.atlassian.net/browse/SRE-3246